### PR TITLE
Bumping jinja2 version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ include_package_data = true
 packages = find:
 python_requires = >=3.6,<4.0
 install_requires =
-    Jinja2 ~= 2.11
+    Jinja2 >= 2.11
     Pygments ~= 2.6.1
     pymdown_extensions ~= 7.1
 


### PR DESCRIPTION
Allow jinja2 version to be greater than 2.11.

Flask installs 3.01 at the moment. Install jinja-markdown after it causes downgrade to 2.11.